### PR TITLE
Observability: only calls + latency views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,9 @@
 # ocjdbc
 OpenCensus instrumented JDBC wrapper for tracing and metrics
 
-## Metrics provided
-
-### Tag keys
-Every metric is recorded with the following tags:
-* "arch"
-* "java_version"
-* "os_name"
-* "os_version"
-
-
-### Recorded metrics
+## Recorded metrics
 
 Metric|Search suffix|Additional tags
 ---|---|---
-Number of Calls|"java.sql/client/calls"|"method"
-Errors|"java.sql/client/errors"|"reason"
-Latency in milliseconds|"java.sql/client/latency"|"method"
+Number of Calls|"java.sql/client/calls"|"method", "error", "status"
+Latency in milliseconds|"java.sql/client/latency"|"method", "error", "status"


### PR DESCRIPTION
Observability: only calls + latency views
  
* Reduced the views to only:
- calls
- latency

in favour of tags "status", "error" attached to
those two views. Those tags are succinctly
expressive and easy for users to calculate error
rates and other comparison operations.
The README.md file has also been accordingly updated.

* The calls metric is now obtained by applying the count
aggregation on the MEASURE_LATENCY

* Also where here removed unused functions and tags

Fixes #47