### PR TITLE
Gradle: Use the correct version and remove the developers section.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: "net.ltgt.errorprone"
 apply plugin: "signing"
 
 group = "io.opencensus.integration"
-version = "0.0.2" // CURRENT_OCJDBC_VERSION
+version = "0.0.2-SNAPSHOT" // CURRENT_OCJDBC_VERSION
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -156,18 +156,6 @@ uploadArchives {
                         license {
                             name 'The Apache License, Version 2.0'
                             url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id 'io.opencensus'
-                            name 'OpenCensus Contributors'
-                            email 'census-developers@googlegroups.com'
-                            url 'opencensus.io'
-                            // https://issues.gradle.org/browse/GRADLE-2719
-                            organization = 'OpenCensus Authors'
-                            organizationUrl 'https://www.opencensus.io'
                         }
                     }
                 }


### PR DESCRIPTION
Remove the developers section since this is not part of the OpenCensus core modules.